### PR TITLE
Ignore PKM-IV folder from activity tracking and graph

### DIFF
--- a/dev_activity.py
+++ b/dev_activity.py
@@ -37,7 +37,7 @@ IGNORED_PATH_PARTS = frozenset({
 DEBOUNCE_SECONDS = 300  # 5 minutes
 
 # Projects to never log (e.g. the watcher project itself)
-IGNORED_PROJECTS = frozenset({"dev-activity"})
+IGNORED_PROJECTS = frozenset({"dev-activity", "PKM-IV"})
 
 # Distinct hues for projects (HSV-style, then we'll use HSL in CSS)
 PROJECT_HUES = [
@@ -168,7 +168,7 @@ def load_activity(log_path: Path) -> dict[str, dict[str, int]]:
                 entry = json.loads(line)
                 d = entry.get("date")
                 p = entry.get("project")
-                if d and p:
+                if d and p and p not in IGNORED_PROJECTS:
                     by_date[d][p] += 1
             except json.JSONDecodeError:
                 continue


### PR DESCRIPTION
Add PKM-IV to IGNORED_PROJECTS so the watcher won't log changes from it,
and filter ignored projects when loading activity data for graph generation
to exclude any previously logged entries.

Closes #1

https://claude.ai/code/session_01Gz6oPHfyppJ4UhZKxSVVRW